### PR TITLE
Compatibility with dplyr 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ LazyData: true
 RoxygenNote: 7.2.3
 Imports:
   ggplot2 (>= 3.3.3),
-  dplyr (>= 1.0.3),
+  dplyr (>= 1.1.0),
   forcats (>= 0.5.0),
   stringr (>= 1.4.0),
   purrr (>= 0.3.4),

--- a/R/QC_clean.R
+++ b/R/QC_clean.R
@@ -152,15 +152,14 @@ nums_to_NA <- function (data, ..., nums_to_replace = NULL) {
   if (missing(...)) {
     data %>%
       dplyr::mutate(dplyr::across(where(is.numeric),
-                                  NA_clean,
-                                  nums_to_replace)
+                                  function(x) NA_clean(x, nums_to_replace))
                     )
   } else {
     vars <- dplyr::enquos(...)
 
     data %>%
       dplyr::mutate(dplyr::across(.cols = c(!!! vars),
-                                  .fns = NA_clean, nums_to_replace)
+                                  .fns = function(x) NA_clean(x, nums_to_replace))
                     )
   }
 }
@@ -248,13 +247,11 @@ encode_bin_cat_vec <- function(x, values = NULL, numeric_out = FALSE) {
 
 encode_binary_cats <- function(data, ..., values = NULL) {
   warn_missing_dots(missing(...))
-  values <- dplyr::enquo(values)
   vars <- dplyr::enquos(...)
 
   data %>%
     dplyr::mutate(dplyr::across(c(!!! vars),
-                                encode_bin_cat_vec,
-                                values = !! values))
+                                function(x) encode_bin_cat_vec(x, values = values)))
 }
 
 ##' Encode ordinal variables

--- a/R/internal_consist.R
+++ b/R/internal_consist.R
@@ -292,7 +292,7 @@ identify_inconsistency <- function(data = NULL, consis_tbl = NULL, id_var = NULL
       dplyr::mutate(lgl_incon = .data$lgl_values %>%
                       purrr::map(. %>%
                                    purrr::map_lgl(function(x) !eval(rlang::parse_expr(x))))) %>%
-      dplyr::mutate(lgl_values = dplyr::na_if(.data$lgl_values, "NA")) ->
+      dplyr::mutate(lgl_values = dplyr::na_if(.data$lgl_values, list("NA"))) ->
       consis_tbl
   } else{}
 


### PR DESCRIPTION
dplyr 1.1.0 is on its way to CRAN right now.

The checks run by CRAN noticed that eHDPrep is broken by this dplyr release, and it somehow slipped through our own reverse dependency checks.

- `na_if()` now casts `y` to the type of `x` and requires that `y` be a compatible type. A character `"NA"` is not a compatible type with a list-column. It seems like you should be using `list("NA")` here instead, so I've changed to that.
- We have also deprecated usage of `...` in `across()` and instead encourage using anonymous functions. Those were only throwing warnings but I went ahead and updated those too